### PR TITLE
refactor: improve chart type safety

### DIFF
--- a/src/app/components/PopularPlaceTypesChart.tsx
+++ b/src/app/components/PopularPlaceTypesChart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  TooltipProps,
 } from "recharts";
 import {
   Card,
@@ -59,7 +60,15 @@ export default function PopularPlaceTypesChart() {
 
   const totalVisitors = data.reduce((sum, c) => sum + c.visitors, 0);
 
-  const renderCustomTooltip = ({ active, payload }: any) => {
+  interface CategoryData {
+    name: string;
+    visitors: number;
+  }
+
+  const renderCustomTooltip = ({
+    active,
+    payload,
+  }: TooltipProps<number, string, CategoryData>) => {
     if (active && payload && payload.length > 0) {
       const { name, visitors } = payload[0].payload;
       const percentage = ((visitors / totalVisitors) * 100).toFixed(1);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,7 +12,7 @@ import LocationDetailDialog from "@/app/components/LocationDetailDialog";
 import { useBIData } from "@/hooks/useBIData";
 import { ExternalLocation } from "@/types/geo";
 import SearchBox from "@/app/components/SearchBox";
-import VisitorsByCategoryChart from "../components/ PopularPlaceTypesChart";
+import VisitorsByCategoryChart from "../components/PopularPlaceTypesChart";
 
 export default function DashboardPage() {
   const [selectedCoords, setSelectedCoords] = useState<[number, number] | null>(


### PR DESCRIPTION
## Summary
- replace `any` tooltip typing with explicit `TooltipProps` and `CategoryData`
- rename PopularPlaceTypesChart to remove leading space and update import

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ee3dc3fa48327a9b264608ee6fe4f