### PR TITLE
Add Jest testing scaffold

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -32,6 +33,11 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/src/__tests__/sample.test.tsx
+++ b/src/__tests__/sample.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+function SampleComponent() {
+  return <div>Hello, Jest!</div>;
+}
+
+test('renders greeting', () => {
+  render(<SampleComponent />);
+  expect(screen.getByText('Hello, Jest!')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest config with ts-jest for TypeScript testing
- create sample React test using Testing Library
- add Jest test script and dependencies in package.json

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eec6b527c832792a9a7d8d8718fb6