### PR TITLE
Use env var for Foursquare API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment Variables
+
+To fetch data from the Foursquare Places API, the app expects a Foursquare API key. Create a `.env.local` file in the project root with the following entry:
+
+```
+NEXT_PUBLIC_FSQ_API_KEY=your_foursquare_api_key
+```
+
+The `NEXT_PUBLIC_` prefix ensures Next.js exposes the key to client-side code during the build step. Remember to define this variable whenever you run `npm run dev` or `npm run build`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   images: {
     domains: ["ss3.4sqi.net"], // ✅ allow Foursquare icons
   },
+  env: {
+    NEXT_PUBLIC_FSQ_API_KEY: process.env.NEXT_PUBLIC_FSQ_API_KEY,
+  },
 };
 
 export default nextConfig;

--- a/src/hooks/useExternalLocations.ts
+++ b/src/hooks/useExternalLocations.ts
@@ -55,11 +55,12 @@ export function useExternalLocations(region: string) {
       setLoading(true);
       try {
         const queryCity = region === "all" ? "Tokyo" : region;
+        const apiKey = process.env.NEXT_PUBLIC_FSQ_API_KEY ?? "";
         const response = await fetch(
           `https://api.foursquare.com/v3/places/search?near=${queryCity}&limit=50`,
           {
             headers: {
-              Authorization: "fsq31DatSVBL6U8bi06l6nzMGZP9b4R3/U8AhCqGE5umxJU=",
+              Authorization: apiKey,
             },
           }
         );


### PR DESCRIPTION
## Summary
- replace hard-coded Foursquare Places API key with `process.env.NEXT_PUBLIC_FSQ_API_KEY`
- expose Foursquare key to the client via `next.config.ts`
- document required `NEXT_PUBLIC_FSQ_API_KEY` variable in the project README

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eef006a8c8327a1e3f296332a89c7