### PR TITLE
feat: use env var for MapTiler style

### DIFF
--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -35,10 +35,11 @@ export default function Map({
   useEffect(() => {
     if (!mapContainerRef.current || mapRef.current) return;
 
+    const styleUrl = `https://api.maptiler.com/maps/streets-v2/style.json?key=${process.env.NEXT_PUBLIC_MAPTILER_KEY}`;
+
     const map = new maplibregl.Map({
       container: mapContainerRef.current,
-      style:
-        "https://api.maptiler.com/maps/streets-v2/style.json?key=eZB5Vbk73nkRL0i19Gz6",
+      style: styleUrl,
       center: [139.6917, 35.6895],
       zoom: 15,
       pitch: 60,


### PR DESCRIPTION
## Summary
- build MapTiler style URL using NEXT_PUBLIC_MAPTILER_KEY instead of hardcoded key

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for @types/jest)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eef07b64083279d1a28f5be5851b9