### PR TITLE
chore: remove i dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@mui/material-nextjs": "^6.1.6",
         "@mui/system": "^6.1.7",
         "@tanstack/react-query": "^5.72.2",
-        "i": "^0.3.7",
         "maplibre-gl": "^5.3.0",
         "next": "15.3.0",
         "react": "^19.0.0",
@@ -4266,14 +4265,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/i": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
-      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@mui/material-nextjs": "^6.1.6",
     "@mui/system": "^6.1.7",
     "@tanstack/react-query": "^5.72.2",
-    "i": "^0.3.7",
     "maplibre-gl": "^5.3.0",
     "next": "15.3.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- remove unused i package from dependencies

## Testing
- `npm install --package-lock-only --legacy-peer-deps` (fails: 403 Forbidden to registry)
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_688eef1f5be083279c8422bb95a6d8bc